### PR TITLE
Add FrameHandleParts shape

### DIFF
--- a/example/select/select_framehandle_test.c
+++ b/example/select/select_framehandle_test.c
@@ -1,0 +1,200 @@
+#include <roki_gl/roki_glut.h>
+
+typedef struct{
+  GLint list;
+  int updown;
+} partsInfo_t;
+
+#define NOBJECTS 6
+typedef struct{
+  partsInfo_t partsInfo[NOBJECTS];
+  zFrame3D frame;
+} frameHandle_t;
+
+/* the main target of this sample code */
+frameHandle_t g_fh;
+
+#define NPOSSIZE 3
+static const zAxis g_AXES[NOBJECTS] = {zX, zY, zZ, zXA, zYA, zZA};
+
+rkglCamera cam;
+rkglLight light;
+
+static const double g_LENGTH = 2.0;
+static const double g_MAGNITUDE = 1.0;
+
+/* draw FrameHandle parts shape */
+void draw_fhpts(int id, void (*fhpts_callback)(zFrame3D*, zAxis, double, double, bool))
+{
+  /* frame.ang (AA) -> angle & axis */
+  zVec6D aa;
+  zFrame3DToVec6DAA( &g_fh.frame, &aa );
+  zVec3D axis;
+  double angle = zVec3DNormalize( zVec6DAng( &aa ), &axis );
+
+  /* start draw */
+  glLoadName( id );
+  glPushMatrix();
+
+  if( g_fh.partsInfo[id].updown == 0 )
+    fhpts_callback( &g_fh.frame, g_AXES[id], g_LENGTH, g_MAGNITUDE, false );
+  else
+    fhpts_callback( &g_fh.frame, g_AXES[id], g_LENGTH, g_MAGNITUDE, true );
+
+  glTranslated( g_fh.frame.pos.c.x, g_fh.frame.pos.c.y, g_fh.frame.pos.c.y );
+  glRotated( angle, axis.c.x, axis.c.y, axis.c.z);
+
+  glCallList( g_fh.partsInfo[id].list );
+  glPopMatrix();
+  /* end draw */
+}
+
+void draw_scene(void)
+{
+  /* pos */
+  int i = 0;
+  for( i = 0; i < NPOSSIZE; i++ )
+  {
+    draw_fhpts( i, rkglFrameHandleArrowParts );
+  }
+  /* rot */
+  for( i = NPOSSIZE; i < NOBJECTS; i++ )
+  {
+    draw_fhpts( i, rkglFrameHandleTorusParts );
+  }
+}
+
+void display(void)
+{
+  rkglCALoad( &cam );
+  rkglLightPut( &light );
+  rkglClear();
+  draw_scene();
+  glutSwapBuffers();
+}
+
+static int selected_parts_id = -1;
+
+void reset_parts(void)
+{
+  if( selected_parts_id >= 0 ){
+    glDeleteLists( g_fh.partsInfo[ selected_parts_id ].list, 1 );
+    g_fh.partsInfo[ selected_parts_id ].list = -1;
+    g_fh.partsInfo[ selected_parts_id ].updown = 0;
+
+    selected_parts_id = -1;
+  }
+}
+
+void select_parts(GLuint selbuf[], int hits)
+{
+  GLuint *ns;
+
+  reset_parts();
+  if( !( ns = rkglFindNearside( selbuf, hits ) ) ) return;
+  selected_parts_id = ns[3]; /* simple reference to link name */
+
+  if( selected_parts_id >= 0 && selected_parts_id < NOBJECTS )
+    g_fh.partsInfo[ selected_parts_id ].updown = 1;
+}
+
+void mouse(int button, int state, int x, int y)
+{
+  GLuint selbuf[BUFSIZ];
+
+  switch( button ){
+  case GLUT_LEFT_BUTTON:
+    if( state == GLUT_DOWN )
+      select_parts( selbuf, rkglPick( &cam, draw_scene, selbuf, BUFSIZ, x, y, 1, 1 ) );
+    break;
+  case GLUT_MIDDLE_BUTTON:
+    break;
+  case GLUT_RIGHT_BUTTON:
+    break;
+  default: ;
+  }
+
+  if( selected_parts_id == -1 )
+  {
+    rkglMouseFuncGLUT(button, state, x, y);
+  }
+}
+
+void motion(int x, int y)
+{
+  if( selected_parts_id == -1 ){
+    rkglMouseDragFuncGLUT(x, y);
+  }
+}
+
+void resize(int w, int h)
+{
+  rkglVPCreate( &cam, 0, 0, w, h );
+  rkglFrustumScale( &cam, 0.002, 1, 20 );
+}
+
+void keyboard(unsigned char key, int x, int y)
+{
+  switch( key ){
+  case 'u': rkglCALockonPTR( &cam, 5, 0, 0 ); break;
+  case 'U': rkglCALockonPTR( &cam,-5, 0, 0 ); break;
+  case 'i': rkglCALockonPTR( &cam, 0, 5, 0 ); break;
+  case 'I': rkglCALockonPTR( &cam, 0,-5, 0 ); break;
+  case 'o': rkglCALockonPTR( &cam, 0, 0, 5 ); break;
+  case 'O': rkglCALockonPTR( &cam, 0, 0,-5 ); break;
+  case '8': rkglCARelMove( &cam, 0.05, 0, 0 ); break;
+  case '*': rkglCARelMove( &cam,-0.05, 0, 0 ); break;
+  case '9': rkglCARelMove( &cam, 0, 0.05, 0 ); break;
+  case '(': rkglCARelMove( &cam, 0,-0.05, 0 ); break;
+  case '0': rkglCARelMove( &cam, 0, 0, 0.05 ); break;
+  case ')': rkglCARelMove( &cam, 0, 0,-0.05 ); break;
+  case 'q': case 'Q': case '\033':
+    exit( EXIT_SUCCESS );
+  default: ;
+  }
+}
+
+void init(void)
+{
+  rkglSetCallbackParamGLUT( &cam, 0, 0, 0, 0, 0 );
+
+  rkglBGSet( &cam, 0.5, 0.5, 0.5 );
+  rkglCASet( &cam, 5, 0, 2, 0, -20, 0 );
+
+  glEnable( GL_LIGHTING );
+  rkglLightCreate( &light, 0.4, 0.4, 0.4, 1, 1, 1, 0, 0, 0 );
+  rkglLightMove( &light, 8, 0, 8 );
+
+  int i;
+  for( i=0; i<NOBJECTS; i++ ){
+    g_fh.partsInfo[i].updown = 0;
+    glDeleteLists( g_fh.partsInfo[i].list, 1 );
+    g_fh.partsInfo[i].list = glGenLists( 1 );
+    glNewList( g_fh.partsInfo[i].list, GL_COMPILE );
+    glEndList();
+  }
+}
+
+void idle(void){ glutPostRedisplay(); }
+
+int main(int argc, char *argv[])
+{
+  /* initialize */
+  zFrame3DFromAA( &g_fh.frame, 0.0, 0.0, 0.0,  0.0, 0.0, 1.0);
+
+  rkglInitGLUT( &argc, argv );
+  rkglWindowCreateGLUT( 0, 0, 320, 320, argv[0] );
+
+  glutDisplayFunc( display );
+  glutMouseFunc( mouse );
+
+  /* Add */
+  glutMotionFunc( motion );
+
+  glutReshapeFunc( resize );
+  glutKeyboardFunc( keyboard );
+  glutIdleFunc( idle );
+  init();
+  glutMainLoop();
+  return 0;
+}

--- a/include/roki_gl/rkgl_shape.h
+++ b/include/roki_gl/rkgl_shape.h
@@ -72,6 +72,8 @@ __ROKI_GL_EXPORT void rkglPointCloud(zVec3DList *pc, zVec3D *center, short size)
 __ROKI_GL_EXPORT void rkglArrow(zVec3D *bot, zVec3D *vec, double mag);
 
 __ROKI_GL_EXPORT void rkglFrame(zFrame3D *f, double l, double mag);
+__ROKI_GL_EXPORT void rkglFrameHandleArrowParts(zFrame3D *f, zAxis a, double l, double mag, bool is_white);
+__ROKI_GL_EXPORT void rkglFrameHandleTorusParts(zFrame3D *f, zAxis a, double l, double mag, bool is_white);
 __ROKI_GL_EXPORT void rkglFrameHandle(zFrame3D *f, double l, double mag);
 
 __ROKI_GL_EXPORT void rkglAxis(zAxis axis, double d, double w, GLfloat color[]);

--- a/src/rkgl_shape.c
+++ b/src/rkgl_shape.c
@@ -957,6 +957,78 @@ void rkglFrame(zFrame3D *f, double l, double mag)
   rkglArrow( zFrame3DPos(f), &v, mag );
 }
 
+static void _rkglFrameHandleArrowPartsAxis(zFrame3D *f, zAxis a, double l, double mag)
+{
+  zVec3D v, vb;
+
+  zVec3DMul( &zFrame3DAtt(f)->v[a], 0.5*l, &v );
+  zVec3DAdd( zFrame3DPos(f), &v, &vb );
+  rkglArrow( &vb, &v, mag );
+  zVec3DRevDRC( &v );
+  zVec3DAdd( zFrame3DPos(f), &v, &vb );
+  rkglArrow( &vb, &v, mag );
+}
+
+void rkglFrameHandleArrowParts(zFrame3D *f, zAxis a, double l, double mag, bool is_white)
+{
+  if( is_white ){
+    /* White */
+    rkglMaterial( NULL );
+  } else {
+    zOpticalInfo oi;
+    if(a == zX){
+      /* Red */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    } else
+    if(a == zY){
+      /* Green */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    } else
+    if(a == zZ){
+      /* Blue */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    }
+    rkglMaterial( &oi );
+  }
+
+  _rkglFrameHandleArrowPartsAxis( f, a, l, mag );
+}
+
+static void _rkglFrameHandleTorusPartsAxis(zFrame3D *f, zAxis a, double l, double mag)
+{
+  double r1, r2;
+
+  r1 = l * 0.5 + RKGL_ARROW_BOTTOM_RAD * mag;
+  r2 = l * 0.5 - RKGL_ARROW_BOTTOM_RAD * mag;
+
+  rkglTorus( zFrame3DPos(f), &zFrame3DAtt(f)->v[a], r1, r2, RKGL_ARROW_DIV*4, RKGL_ARROW_DIV, RKGL_FACE );
+}
+
+void rkglFrameHandleTorusParts(zFrame3D *f, zAxis a, double l, double mag, bool is_white)
+{
+  if( is_white ){
+    /* White */
+    rkglMaterial( NULL );
+  } else{
+    zOpticalInfo oi;
+    if(a == zXA){
+      /* Red */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    } else
+    if(a == zYA){
+      /* Green */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    } else
+    if(a == zZA){
+      /* Blue */
+      zOpticalInfoCreate( &oi, 0.5, 0.5, 0.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.5, NULL );
+    }
+    rkglMaterial( &oi );
+  }
+
+  _rkglFrameHandleTorusPartsAxis( f, a, l, mag );
+}
+
 static void _rkglFrameHandleAxis(zFrame3D *f, zAxis a, double l, double mag, double r1, double r2)
 {
   zVec3D v, vb;


### PR DESCRIPTION
## overview
Using the existing FrameHandle as a reference, we defined an object divided into arrow and torus parts.  

Added files :  

- include/roki_gl/rkgl_shape.h
- src/rkgl_shape.c

Added functions.  
 
- rkglFrameHandleArrowParts()
- rkglFrameHandleTorusParts()

follows arguments are almost same as exisiting FrameHandle() but the only 'is_white' of the last argument is different.  
'is_white' is a flag that indicates whether to display in white to visualize the selection state.  

## sample
Added code to visualize FrameHandle component selection by referring to existing sample code (frame_test.c, select_test.c).  

Added files  
- example/select/select_framehandle_test.c

![select_framehandle_test-2023-11-22_11 03 34](https://github.com/mi-lib/roki-gl/assets/50308849/d6bf5efd-5b52-4c07-b99a-a4154f01c323)
