### PR TITLE
Add a new API rkglCopyFromDefaultCamera()

### DIFF
--- a/include/roki_gl/rkgl_camera.h
+++ b/include/roki_gl/rkgl_camera.h
@@ -133,6 +133,7 @@ __ROKI_GL_EXPORT double rkgl_default_key_delta_trans;
 __ROKI_GL_EXPORT double rkgl_default_key_delta_angle;
 
 __ROKI_GL_EXPORT void rkglSetDefaultCallbackParam(rkglCamera *cam, double width, double near, double far, double dl, double da);
+__ROKI_GL_EXPORT void rkglCopyFromDefaultCamera(rkglCamera *cam_dest);
 
 __END_DECLS
 

--- a/src/rkgl_camera.c
+++ b/src/rkgl_camera.c
@@ -304,3 +304,9 @@ void rkglSetDefaultCallbackParam(rkglCamera *cam, double width, double near, dou
   rkgl_default_key_delta_trans = dl;
   rkgl_default_key_delta_angle = da;
 }
+
+void rkglCopyFromDefaultCamera(rkglCamera *cam_dest)
+{
+  if( rkgl_default_cam )
+    rkglCameraCopy( rkgl_default_cam, cam_dest );
+}


### PR DESCRIPTION
As the title suggests, I propose an API to copy rkgl_default_cam.

background :  
Previously it was only possible to set one global rkgl_default_cam in one direction by setDefaultCallbackParam().
This was useful when setting up multiple different cameras and switching between them.
Conversely, there may be cases where a copy from rkgl_default_cam is wanted. 
For example, the case that the camera is temporarily moved and then returned to the original camera parameters.  
A simple way to achieve this case is to copy the camera settings and keep them while moving.
Alternatively, there is also a way to explicitly know the camera settings in advance and share them.  
However, rkgl_default_cam is already mostly shared (but API is set only). Therefore, just copying of rkgl_default_cam could acomplish above request, there is no need to implement sharing multiple camera settings or knowing each other at a higher user level.